### PR TITLE
Fixed #20488 -- Added copy and move methods to the storage API

### DIFF
--- a/django/core/files/copy.py
+++ b/django/core/files/copy.py
@@ -1,0 +1,47 @@
+"""
+Copy a file in the safest way possible::
+
+    >>> from django.core.files.copy import file_copy_safe
+    >>> file_copy_safe("/tmp/old_file", "/tmp/new_file")
+"""
+
+import os
+from django.core.files import locks
+
+
+try:
+    from shutil import copystat
+except ImportError:
+    import stat
+    def copystat(src, dst):
+        """Copy all stat info (mode bits, atime and mtime) from src to dst"""
+        st = os.stat(src)
+        mode = stat.S_IMODE(st.st_mode)
+        if hasattr(os, 'utime'):
+            os.utime(dst, (st.st_atime, st.st_mtime))
+        if hasattr(os, 'chmod'):
+            os.chmod(dst, mode)
+
+
+def file_copy_safe(old_file_name, new_file_name, chunk_size=1024*64, allow_overwrite=False):
+    """
+    Copy a file from one location to another in the safest way possible.
+
+    If the destination file exists and ``allow_overwrite`` is ``False``, this
+    function will throw an ``IOError``.
+    """
+    # first open the old file, so that it won't go away
+    with open(old_file_name, 'rb') as old_file:
+        # now open the new file, not forgetting allow_overwrite
+        fd = os.open(new_file_name, os.O_WRONLY | os.O_CREAT | getattr(os, 'O_BINARY', 0) |
+                                    (not allow_overwrite and os.O_EXCL or 0))
+        try:
+            locks.lock(fd, locks.LOCK_EX)
+            current_chunk = None
+            while current_chunk != b'':
+                current_chunk = old_file.read(chunk_size)
+                os.write(fd, current_chunk)
+        finally:
+            locks.unlock(fd)
+            os.close(fd)
+    copystat(old_file_name, new_file_name)

--- a/django/core/files/copy.py
+++ b/django/core/files/copy.py
@@ -9,6 +9,8 @@ import os
 from django.core.files import locks
 
 
+__all__ = ['file_copy_safe']
+
 try:
     from shutil import copystat
 except ImportError:
@@ -41,6 +43,9 @@ def file_copy_safe(old_file_name, new_file_name, chunk_size=1024*64, allow_overw
             while current_chunk != b'':
                 current_chunk = old_file.read(chunk_size)
                 os.write(fd, current_chunk)
+        except OSError:
+            os.remove(new_file_name)
+            raise
         finally:
             locks.unlock(fd)
             os.close(fd)

--- a/django/core/files/copy.py
+++ b/django/core/files/copy.py
@@ -6,23 +6,12 @@ Copy a file in the safest way possible::
 """
 
 import os
+from shutil import copystat
+
 from django.core.files import locks
 
 
 __all__ = ['file_copy_safe']
-
-try:
-    from shutil import copystat
-except ImportError:
-    import stat
-    def copystat(src, dst):
-        """Copy all stat info (mode bits, atime and mtime) from src to dst"""
-        st = os.stat(src)
-        mode = stat.S_IMODE(st.st_mode)
-        if hasattr(os, 'utime'):
-            os.utime(dst, (st.st_atime, st.st_mtime))
-        if hasattr(os, 'chmod'):
-            os.chmod(dst, mode)
 
 
 def file_copy_safe(old_file_name, new_file_name, chunk_size=1024*64, allow_overwrite=False):

--- a/django/core/files/move.py
+++ b/django/core/files/move.py
@@ -6,20 +6,8 @@ Move a file in the safest way possible::
 """
 
 import os
-from django.core.files import locks
+from django.core.files.copy import file_copy_safe
 
-try:
-    from shutil import copystat
-except ImportError:
-    import stat
-    def copystat(src, dst):
-        """Copy all stat info (mode bits, atime and mtime) from src to dst"""
-        st = os.stat(src)
-        mode = stat.S_IMODE(st.st_mode)
-        if hasattr(os, 'utime'):
-            os.utime(dst, (st.st_atime, st.st_mtime))
-        if hasattr(os, 'chmod'):
-            os.chmod(dst, mode)
 
 __all__ = ['file_move_safe']
 
@@ -34,6 +22,7 @@ def _samefile(src, dst):
     # All other platforms: check for same pathname.
     return (os.path.normcase(os.path.abspath(src)) ==
             os.path.normcase(os.path.abspath(dst)))
+
 
 def file_move_safe(old_file_name, new_file_name, chunk_size = 1024*64, allow_overwrite=False):
     """
@@ -58,21 +47,7 @@ def file_move_safe(old_file_name, new_file_name, chunk_size = 1024*64, allow_ove
         # or when moving opened files on certain operating systems
         pass
 
-    # first open the old file, so that it won't go away
-    with open(old_file_name, 'rb') as old_file:
-        # now open the new file, not forgetting allow_overwrite
-        fd = os.open(new_file_name, os.O_WRONLY | os.O_CREAT | getattr(os, 'O_BINARY', 0) |
-                                    (not allow_overwrite and os.O_EXCL or 0))
-        try:
-            locks.lock(fd, locks.LOCK_EX)
-            current_chunk = None
-            while current_chunk != b'':
-                current_chunk = old_file.read(chunk_size)
-                os.write(fd, current_chunk)
-        finally:
-            locks.unlock(fd)
-            os.close(fd)
-    copystat(old_file_name, new_file_name)
+    file_copy_safe(old_file_name, new_file_name, chunk_size, allow_overwrite)
 
     try:
         os.remove(old_file_name)

--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 from django.core.files import locks, File
+from django.core.files.copy import file_copy_safe
 from django.core.files.move import file_move_safe
 from django.utils.encoding import force_text, filepath_to_uri
 from django.utils.functional import LazyObject
@@ -145,6 +146,19 @@ class Storage(object):
         """
         raise NotImplementedError()
 
+    def move(self, src_name, dst_name):
+        """
+        Move file specified by src_name to dst_name.
+        """
+        raise NotImplementedError()
+
+    def copy(self, src_name, dst_name):
+        """
+        Copy file specified by src_name to dst_name.
+        """
+        raise NotImplementedError()
+
+
 class FileSystemStorage(Storage):
     """
     Standard filesystem storage
@@ -279,6 +293,17 @@ class FileSystemStorage(Storage):
 
     def modified_time(self, name):
         return datetime.fromtimestamp(os.path.getmtime(self.path(name)))
+
+    def move(self, src_name, dst_name):
+        src_path = self.path(src_name)
+        dst_path = self.path(dst_name)
+        file_move_safe(src_path, dst_path)
+
+    def copy(self, src_name, dst_name):
+        src_path = self.path(src_name)
+        dst_path = self.path(dst_name)
+        file_copy_safe(src_path, dst_path)
+
 
 def get_storage_class(import_path=None):
     return import_by_path(import_path or settings.DEFAULT_FILE_STORAGE)

--- a/django/core/files/storage.py
+++ b/django/core/files/storage.py
@@ -148,13 +148,13 @@ class Storage(object):
 
     def move(self, src_name, dst_name):
         """
-        Move file specified by src_name to dst_name.
+        Move the file specified by src_name to dst_name.
         """
         raise NotImplementedError()
 
     def copy(self, src_name, dst_name):
         """
-        Copy file specified by src_name to dst_name.
+        Copy the file specified by src_name to dst_name.
         """
         raise NotImplementedError()
 

--- a/docs/ref/files/storage.txt
+++ b/docs/ref/files/storage.txt
@@ -59,8 +59,9 @@ The Storage Class
 
     .. method:: copy(src_name, dst_name)
 
-        Copy the file specified by src_name to dst_name. For storage systems that
-        don't support copy this will raise ``NotImplementedError`` instead.
+        Copy the file specified by src_name to dst_name. If dst_name already exists
+        ``ValueError`` will be raised. For storage systems that don't
+        support copy this will raise ``NotImplementedError`` instead.
 
     .. method:: created_time(name)
 
@@ -107,8 +108,9 @@ The Storage Class
 
     .. method:: move(src_name, dst_name)
 
-        Move the file specified by src_name to dst_name. For storage systems that
-        don't support move this will raise ``NotImplementedError`` instead.
+        Move the file specified by src_name to dst_name. If dst_name already exists
+        ``ValueError`` will be raised. For storage systems that don't
+        support move this will raise ``NotImplementedError`` instead.
 
     .. method:: open(name, mode='rb')
 

--- a/docs/ref/files/storage.txt
+++ b/docs/ref/files/storage.txt
@@ -57,6 +57,11 @@ The Storage Class
         file. For storage systems that aren't able to return the last accessed
         time this will raise ``NotImplementedError`` instead.
 
+    .. method:: copy(src_name, dst_name)
+
+        Copy the file specified by src_name to dst_name. For storage systems that
+        don't support copy this will raise ``NotImplementedError`` instead.
+
     .. method:: created_time(name)
 
         Returns a ``datetime`` object containing the creation time of the file.
@@ -100,6 +105,11 @@ The Storage Class
         storage systems that aren't able to return the last modified time, this
         will raise ``NotImplementedError`` instead.
 
+    .. method:: move(src_name, dst_name)
+
+        Move the file specified by src_name to dst_name. For storage systems that
+        don't support move this will raise ``NotImplementedError`` instead.
+
     .. method:: open(name, mode='rb')
 
         Opens the file given by ``name``. Note that although the returned file
@@ -135,3 +145,4 @@ The Storage Class
         Returns the URL where the contents of the file referenced by ``name``
         can be accessed. For storage systems that don't support access by URL
         this will raise ``NotImplementedError`` instead.
+

--- a/tests/file_storage/tests.py
+++ b/tests/file_storage/tests.py
@@ -383,7 +383,7 @@ class FileStorageTests(FileStorageTestsBase):
         f = ContentFile('content content')
         existing_name = self.storage.save('existing.file', f)
         src_name = self.storage.save('src.file', f)
-        with self.assertRaises(OSError):
+        with self.assertRaises(ValueError):
             self.storage.copy(src_name, existing_name)
 
     def test_move_file(self):


### PR DESCRIPTION
- also implemented these methods in the default FileSystemStorage
- fix issue with storage tests: each test from FileStorageTests
  was run twice (when inheriting from a TestCase class all test_
  methods are ran in the subclass as well)
